### PR TITLE
update cluster_svinfo.js

### DIFF
--- a/SVClassifyStream.js
+++ b/SVClassifyStream.js
@@ -76,7 +76,23 @@ function SVClassifyStream(dir, options) {
     compare: function(sv1, sv2) {
       var score1 = Number(sv1.score);
       var score2 = Number(sv2.score);
-      return (score1 > score2) ? -1: 1; // order by score desc
+      //return (score1 > score2) ? -1: 1; // order by score desc
+      var start1 = Number(sv1.start);
+      var start2 = Number(sv2.start);
+      var rc;
+      if(score1 > score2){
+        rc = -1; //score is descending order
+      }else if(score1 < score2){
+        rc = 1;  //score is descending order
+      }else{ //score1 == score2
+        if(start1 > start2){
+          rc = 1; //start address is ascending order
+        }else{
+          rc = -1;
+        }
+      }
+      return rc;
+
     }
   });
 

--- a/subs/cluster_svinfo.js
+++ b/subs/cluster_svinfo.js
@@ -33,11 +33,12 @@ function cluster_svinfo(input, config) {
     console.log(line.trim());
   });
 
-  var lines = new LineStream(input, {
-    fieldNum: 2,
-    fieldSep: "\t",
-    comment: "#"
-  });
+  //var lines = new LineStream(input, {
+  //  fieldNum: 2,
+  //  fieldSep: "\t",
+  //  comment: "#"
+  //});
+  var lines = new LineStream(input); //no format filter
 
   var clusters = {};
 

--- a/subs/cluster_svinfo.js
+++ b/subs/cluster_svinfo.js
@@ -22,7 +22,7 @@ function cluster_svinfo(input, config) {
   // var RF_JSON  = (config.RF_JSON) ? require(config.RF_JSON) : null;
   // self.freader = new FASTAReader(RF_FASTA, RF_JSON);
 
-  var MAX_DIFF = config.MAX_DIFF || 3;
+  var SV_MAX_DIFF = config.SV_MAX_DIFF || 3;
   var MIN_CLUSTER_SIZE = config.MIN_CLUSTER_SIZE || 10;
   var SAVE_DIR = config.SAVE_DIR || (__dirname + '../');
 
@@ -89,11 +89,11 @@ function cluster_svinfo(input, config) {
     /**
      * checking if cluster and current are in different clusters
      **/
-    if( ( Math.abs(cluster.get('start') - current.start) > MAX_DIFF)
+    if( ( Math.abs(cluster.get('start') - current.start) > SV_MAX_DIFF)
       ||
-      ( current.type != 'INS' && current.type != 'CTX' && Math.abs(cluster.get('end') - current.end) > MAX_DIFF)
+      ( current.type != 'INS' && current.type != 'CTX' && Math.abs(cluster.get('end') - current.end) > SV_MAX_DIFF)
       ||
-      ( current.type == 'CTX' && Math.abs(cluster.get('start2') - current.start2) > MAX_DIFF)
+      ( current.type == 'CTX' && Math.abs(cluster.get('start2') - current.start2) > SV_MAX_DIFF)
     ) {
 
       printSVInfo.call(self, svcStream, clusters[key],
@@ -253,7 +253,7 @@ if (__filename == process.argv[1]) {
     RF_FASTA: process.argv[2],
     RF_JSON : process.argv[3],
     SAVE_DIR: process.argv[4],
-    MAX_DIFF: process.argv[5],
+    SV_MAX_DIFF: process.argv[5],
     MIN_CLUSTER_SIZE: process.argv[6]
   });
 }


### PR DESCRIPTION
"cluster_svinfo.js" reads data from LineStream with format filter ( at line 36-40).  This filter assumes that there are two field in input record and comment line have '#' in head. 
With my test, input data of "cluster_svinfo.js" is different form from filter. So, I remove filter specification from code, then clipcrop complete process.
I am not sure the reason of this filter, but I update this code to finish clipcrop run. 
